### PR TITLE
Add/Refactor: Trainset augmentations with audiomentations library

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 DATA_PATH = "./data/raw/gtzan_genre"
 LEARNING_RATE = 3e-4
 NUM_EPOCHS = 30
-WITH_AUGMENTATION = False
+WITH_AUGMENTATION = True

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
 DATA_PATH = "./data/raw/gtzan_genre"
 LEARNING_RATE = 3e-4
 NUM_EPOCHS = 30
+WITH_AUGMENTATION = False

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
   - absl-py=2.1.0
+  - audiomentations=0.38.0
   - audioread=3.0.1
   - blas=1.0
   - brotli=1.1.0

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,10 +1,9 @@
 import torch
-import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
 from sklearn.metrics import accuracy_score, confusion_matrix
 from model import CNN
-from gtzan_loader import test_loader, GTZAN_GENRES
+from gtzan_loader import get_dataloader, GTZAN_GENRES
 from datetime import datetime
 
 if __name__ == "__main__":
@@ -21,6 +20,8 @@ if __name__ == "__main__":
     cnn.eval()
     y_true = []
     y_pred = []
+
+    test_loader = get_dataloader(split="test")
 
     with torch.no_grad():
         for wav, genre_index in test_loader:

--- a/gtzan_loader.py
+++ b/gtzan_loader.py
@@ -4,7 +4,7 @@ import torch
 import numpy as np
 import soundfile as sf
 from torch.utils import data
-from config import DATA_PATH
+from config import DATA_PATH, WITH_AUGMENTATION
 
 # from torchaudio_augmentations import (
 #     RandomResizedCrop,
@@ -137,12 +137,12 @@ def get_dataloader(
     return data_loader
 
 
-train_loader = get_dataloader(split="train", is_augmentation=False)
-valid_loader = get_dataloader(split="valid")
-test_loader = get_dataloader(split="test")
 
 
 if __name__ == "__main__":
+    train_loader = get_dataloader(split="train", is_augmentation=WITH_AUGMENTATION)
+    valid_loader = get_dataloader(split="valid")
+    test_loader = get_dataloader(split="test")
     iter_train_loader = iter(train_loader)
     train_wav, train_genre = next(iter_train_loader)
     iter_test_loader = iter(test_loader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 absl-py==2.1.0
+audiomentations==0.38.0
 cffi==1.17.1
 contourpy==1.3.0
 cycler==0.12.1

--- a/train.py
+++ b/train.py
@@ -2,10 +2,10 @@ import numpy as np
 import torch
 from torch import nn
 from model import CNN
-from gtzan_loader import train_loader, valid_loader
+from gtzan_loader import get_dataloader
 from sklearn.metrics import accuracy_score
 from datetime import datetime
-from config import LEARNING_RATE, NUM_EPOCHS
+from config import LEARNING_RATE, NUM_EPOCHS, WITH_AUGMENTATION
 from torch.utils.tensorboard import SummaryWriter
 
 if __name__ == "__main__":
@@ -21,6 +21,10 @@ if __name__ == "__main__":
     optimizer = torch.optim.Adam(cnn.parameters(), lr=LEARNING_RATE)
     valid_losses = []
     num_epochs = NUM_EPOCHS
+
+    # get dataloaders
+    train_loader = get_dataloader(split="train", is_augmentation=WITH_AUGMENTATION)
+    valid_loader = get_dataloader(split="valid")
 
     for epoch in range(num_epochs):
         losses = []


### PR DESCRIPTION
## Trainset augmentations with audiomentations library

### This PR introduces
- Support of audio data augmentation techniques such as `Clip`, `PolarityInversion`, or `PassFilter` (see all supported [here](https://github.com/iver56/audiomentations?tab=readme-ov-file#transforms)) using the [audiomentations](https://github.com/iver56/audiomentations) library, which (1) works, (2) offers more augmentation techniques than `torchaudio_augmentations`, and (3) is still supported by the developers. As `audiomentations` are written in plain numpy, there's no need to convert numpy arrays to torch tensors and back again to augment. 
- Setting trainset augmentation with the `WITH_AUGMENTATION` flag in the `config.py`.
- Instead of creating `train_loader`, `valid_loader` and `test_loader` every time something is imported from `gtzan_loader.py`, dataloaders must be always created using `get_dataloader()` function. 

### Results on example run (n_epochs=30)
| Augmentation     | Best Model Epoch | Train Loss | Valid Loss | Valid Accuracy | Test Accuracy |
|------------------|------------------|------------|------------|----------------|---------------|
| No (before PR)    | 22               | 1.4365     | 1.8767     | 0.3249         | 0.3379        |
| Yes (after PR)      | 29               | 1.7137     | 1.6961     | 0.3756         | 0.3690        |



### Tested on
- Linux and MacOS
- Python **3.11.11** and Python **3.12.3**
